### PR TITLE
ValuePool Dict as JSON Dict

### DIFF
--- a/custom_components/test/fuzzing/fuzzer_utils/ValuePool.py
+++ b/custom_components/test/fuzzing/fuzzer_utils/ValuePool.py
@@ -91,15 +91,12 @@ class ValuePool:
         ]
 
         # set values for __DICT_POOL
-        # a dict is represented as a string and need to be loaded as a json in the testcase
         self.__DICT_POOL = [
-            # None, # test cases can today not handel a None value, the JSON bib can load a NONE value as a JSON
-            "{}",
-            "{\"key\": \"value\"}",
-            "{\"int\": 1, \"float\": 1.0, \"str\": \"string\"}",
-            # Bug:
-            # {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9} is not a valid dict/JSON!
-            # {i: i for i in range(10)},  # dictionary with multiple entries
+             # None, # test cases can today not handel a None value, the JSON bib can load a NONE value as a JSON
+            {},
+            {"key": "value"},
+            {"int": 1, "float": 1.0, "str": "string"},
+            {str(i): i for i in range(10)},  # dictionary with multiple entries
         ]
 
         # set values for __DATE_POOL

--- a/custom_components/test/fuzzing/fuzzer_utils/ValuePool.py
+++ b/custom_components/test/fuzzing/fuzzer_utils/ValuePool.py
@@ -91,12 +91,13 @@ class ValuePool:
         ]
 
         # set values for __DICT_POOL
+        # a dict is represented as a string and need to be loaded as a json in the testcase
         self.__DICT_POOL = [
-            "null",
-            {},
-            {"key": "value"},
-            {"int": 1, "float": 1.0, "str": "string"},
-            {str(i): i for i in range(10)},  # dictionary with multiple entries
+            # None, # test cases can today not handel a None value, the JSON bib can load a NONE value as a JSON
+            "{}",
+            '{"key": "value"}',
+            '{"int": 1, "float": 1.0, "str": "string"}',
+            '{"0": 0, "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8, "9": 9}',
         ]
 
         # set values for __DATE_POOL

--- a/custom_components/test/fuzzing/fuzzer_utils/ValuePool.py
+++ b/custom_components/test/fuzzing/fuzzer_utils/ValuePool.py
@@ -92,7 +92,7 @@ class ValuePool:
 
         # set values for __DICT_POOL
         self.__DICT_POOL = [
-             # None, # test cases can today not handel a None value, the JSON bib can load a NONE value as a JSON
+            "null",
             {},
             {"key": "value"},
             {"int": 1, "float": 1.0, "str": "string"},


### PR DESCRIPTION
@ThorbenCarl can you check if it does now what it should do?
Now it should be consistent as a JSON Dict and not mixed up with a Python Dict.